### PR TITLE
Add blank-space to Web Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 - [Stacker](https://stacker.app) - Build web apps in your browser, without code.
 - [Widgetic](https://widgetic.com) - A marketplace for website building blocks.
 - [Berrry](https://berrry.app) - Transform Twitter posts and Reddit content into functional web applications using AI.
+- [blank-space](https://www.blankspace.build/) - Open-source AI app builder. Alternative to v0, Lovable, and Bolt.
 
 ## Websites
 


### PR DESCRIPTION
## Summary

Adding [blank-space](https://www.blankspace.build/) to the **Web Apps** section.

## Details

- **Repository**: https://github.com/BrandeisPatrick/blank-space
- **Website**: https://www.blankspace.build/
- **Description**: An open-source AI app builder alternative to v0, Lovable, and Bolt
- **Category**: Web Apps / No-code AI builder

This tool allows users to build web applications without coding, making it a perfect fit for the Web Apps section of this awesome list.