### PR TITLE
Add MeterCall to Agentic Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 
 ## Agentic Apps
 - [Manifest](https://www.manifest.build/) - Build governed agentic apps with an AI powered workflow builder.
+- [MeterCall](https://metercall.ai) - Universal API gateway over 10M+ APIs with AI router across 25+ models. Type a sentence in plain English, get a working app. 727+ ready-made modules to fork. Free tier, usage-based pricing.
 
 ## Analytics
 


### PR DESCRIPTION
Adding MeterCall — a universal API gateway with AI router across 25+ models. Lets users type a sentence in plain English and get a working app. 727+ ready-made modules to fork. Free tier, usage-based pricing (like Claude/OpenAI).

Link: https://metercall.ai

Fits Agentic Apps because the platform builds working apps from natural language descriptions, with autonomous API wiring and module composition. Thanks for maintaining this list.