### PR TITLE
Add France Nuage Webstudio to Websites section

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 - [appsmith_](https://www.appsmith.com/) - Frontend as a Service to build internal apps
 - [Bloggi](https://bloggi.co) - A simple blogging platform
 - [Bookmark](https://www.bookmark.com) - Create a Website with AI
+- [France Nuage Webstudio](https://france-nuage.fr) - Managed Webstudio (open-source visual website builder, alternative to Webflow) hosted in France. Sovereign hosting, GDPR compliant.
 - [Grapedrop](https://grapedrop.com) - Free and custom websites and landing pages
 - [IM Creator](https://www.imcreator.com) - Free Website Builder
 - [Jimdo](https://www.jimdo.com) - Your Website Builder‎


### PR DESCRIPTION
Adds [France Nuage Webstudio](https://france-nuage.fr) to the Websites section.

France Nuage offers a managed Webstudio instance (open-source visual website builder, alternative to Webflow) hosted in France with sovereign hosting and GDPR compliance.

- Added in alphabetical order in the Websites section
- Webstudio itself is already listed; France Nuage is a distinct managed hosting service for it