### PR TITLE
Add AuditWidget to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 
 ## Marketing
 
+- [AuditWidget](https://auditwidget.app/?utm_source=github&utm_medium=awesome_list&utm_campaign=awesome_nocode_lowcode) - Embeddable SEO audit widget for marketing sites. Drop a single script tag — visitors run a 12-point analysis and share their email to unlock the full report.
 - [Fomo](https://fomo.com) - Social Proof Marketing Platform
 - [FORTVISION](https://fortvision.com/) - Create interactive experiences that lead to higher conversions.
 - [Hotjar](https://hotjar.com) - See how your visitors are really using your site.


### PR DESCRIPTION
Adding [AuditWidget](https://auditwidget.app/) to the Marketing section.

**What it does:** AuditWidget is an embeddable SEO audit widget. Drop a single `<script>` tag on a website and visitors can run a 12-point SEO analysis (title tags, meta descriptions, HTTPS, mobile-friendliness, page speed, headings, canonicals, etc.) directly on the page. The full report unlocks after the visitor shares their email — so the widget doubles as a lead-capture mechanic for marketing sites and agencies.

**Why this list:** It is purely no-code to install (one script tag, no build step, no SDK), which fits the no-code/low-code Marketing section alongside tools like Hubspot, Hotjar, and Fomo.

- Live at https://auditwidget.app
- Free plan: 5 audits/month, 1 widget, lead capture included — no credit card required
- Fully functional, not a waitlist

Disclosure: I'm the creator of AuditWidget.