### PR TITLE
Add CollabPortals to Internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 
 ## Internal
 
+- [CollabPortals](https://www.collabportals.com) - Turn your Airtable base into a branded client portal with role-based permissions and custom views.
 - [Contractbook](https://contractbook.co) - Efficient Contract Management
 - [ILLA Cloud](https://www.illacloud.com/) - A low-code platform for developers to build internal tools in minutes.
 - [Jet Admin](https://www.jetadmin.io/) - Build Internal tools & Customer Portals with No-Code


### PR DESCRIPTION
Adds CollabPortals to the **Internal** section.

[CollabPortals](https://www.collabportals.com) turns an Airtable base into a branded client portal with role-based permissions, custom views, and per-field access controls. Fits alongside Jet Admin and UI Bakery in the same section.

Entry is inserted in alphabetical order within Internal. Per the contributing guidelines, no new category is needed.