### PR TITLE
Add WeTransform to Data & Scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 - [flatfile](https://flatfile.io/) - The elegant import button for your web app
 - [Hunter](https://hunter.io/?via=joe) - Find email addresses in seconds.
 - [Simplescraper](https://simplescraper.io/) - Extract data from any website in seconds
+- [WeTransform](https://www.wetransform.com) - Embeddable AI file importer for B2B SaaS. Customers upload CSV, Excel, PDF, XML or JSON, the AI maps columns and validates, your system receives clean data through an API.
+
 
 ## Database
 


### PR DESCRIPTION
Adding WeTransform to the Data & Scraping section. It's an embeddable AI file importer for B2B SaaS, a no-code experience for end customers (they upload files in any format, the AI maps to the target schema). It sits naturally next to Flatfile which is already listed in the same section.

The CI workflow validates URLs, https://www.wetransform.com is live.