### PR TITLE
Add NotFair — open-source Claude Code skills for SEO, Google Ads & Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 - [FORTVISION](https://fortvision.com/) - Create interactive experiences that lead to higher conversions.
 - [Hotjar](https://hotjar.com) - See how your visitors are really using your site.
 - [Hubspot](https://hubspot.com) - A full platform of marketing, sales, customer service, and CRM software.
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, Google Ads, and Meta Ads. Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
 - [Rewardful](https://www.getrewardful.com) - Instant Affiliate & Referral Programs for Stripe
 - [Screenzy](https://screenzy.io) - Screenshot beautifier
 - [Ship](https://producthunt.com/ship) - A toolkit to ship awesome products, by Product Hunt ⛵️


### PR DESCRIPTION
Hi, thanks for maintaining this list!

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair), an open-source set of Claude Code agent skills for marketing work (~2.9k stars, MIT license). It covers SEO site analysis, keyword research, meta tags, schema markup, GEO optimization, content writing, Google Ads audits, and Meta (Facebook + Instagram) Ads management. It connects to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

It fits under the Marketing section alongside tools like Hubspot and TinyTools, since it's a no-code/AI-assisted way to run and manage marketing tasks without writing custom code.

Happy to reword, move to a different section, or trim the description if needed. Thanks for considering it!