### PR TITLE
Add CallURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 - [Activepieces](https://www.activepieces.com) - A no-code tool to automate your business.
 - [Appy Pie Automate](https://appypieautomate.ai) - No-code workflow automation platform with 1,000+ integrations to connect Gmail, Slack, Shopify, HubSpot, and more.
 - [BulkPublish](https://www.bulkpublish.com) - Social media API for publishing to 11 platforms with Zapier, n8n, Make.com, and IFTTT integrations. REST API with Python & Node.js SDKs. Free tier available.
+- [CallURL](https://callurl.com) - Create a free AI phone line for any flyer, room, product, assignment, event, form, or workflow. Answers every call and shares by link or QR.
 - [Clay](https://clay.run) - Build tools & workflows to supercharge your team
 - [EasyClaw](https://easyclaw.com) - AI-powered workflow automation platform for ecommerce operations and teams.
 - [IFTTT](https://ifttt.com) - Do more with the services you love.


### PR DESCRIPTION
Adds CallURL to the Automation section.\n\nCallURL lets users make anything talk: create a free AI phone line for any flyer, room, product, assignment, event, form, or workflow. It answers every call and can be shared by link or QR.