### PR TITLE
Add AppEasy to Mobile Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 ## Mobile Apps
 
 - [Adalo](https://www.adalo.com/) - Turn Your Amazing App Concept Into Reality Without Coding!
+- [AppEasy](https://appeasy.studio) - Launch a branded PWA app for content creators in 5 minutes — vertical templates, offline & push notifications, 0% B2C fee.
 - [AppOnboard Studio](https://apponboard.com/) - Where app ideas come to life. No code required.
 - [Appspotr](https://appspotr.com) - Create epic apps without coding
 - [Appstylo](https://appstylo.com) - Mobile App builder maker


### PR DESCRIPTION
Adding **AppEasy** to the `## Mobile Apps` section, alongside Adalo, Thunkable and Convertigo.

### What it is
AppEasy lets content creators (fitness coaches, course teachers, niche educators) launch a branded Progressive Web App in 5 minutes — pick a vertical template, customize branding, upload content. Students install the app to their home screen, get offline access + push notifications, and pay the creator on the creator's own external platform (0% B2C fee).

### Per CONTRIBUTING
- Placed in alphabetical order (between Adalo and AppOnboard Studio).
- Public, live, no waitlist: https://appeasy.studio
- Free 7-day trial; paid plans from $19/mo.

### Disclosure
I'm the maker of AppEasy. Thanks for maintaining the list!