### PR TITLE
Add LLMGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 - [Blog Posts](#blog-posts)
 
 ## Agentic Apps
+- [LLMGraph](https://llmgraph.ai) - No-code visual builder for LLM/AI workflows: turn your docs and models into RAG chatbots and AI agents, then deploy each to a REST API and an embeddable chat widget in one click.
 - [Manifest](https://www.manifest.build/) - Build governed agentic apps with an AI powered workflow builder.
 - [MeterCall](https://metercall.ai) - Universal API gateway over 10M+ APIs with AI router across 25+ models. Type a sentence in plain English, get a working app. 727+ ready-made modules to fork. Free tier, usage-based pricing.
 - [Taskade Genesis](https://docs.taskade.com/genesis-living-system-builder/genesis/) - AI-powered no-code app builder documentation. Build full-stack applications from natural language with integrated automation, AI agents, and workflow execution. Includes workspace DNA architecture and examples.


### PR DESCRIPTION
LLMGraph (https://llmgraph.ai) is a no-code visual builder for LLM/AI workflows: turn your docs and models into RAG chatbots and AI agents, then deploy each to a REST API and an embeddable chat widget in one click.

It fits the **Agentic Apps** category (alongside Manifest and Taskade Genesis). Added a single entry in alphabetical order at the top of that section, following the list's `[Name](link) - Description.` format.