### PR TITLE
Add VibeKit.bot to Agentic Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 - [Manifest](https://www.manifest.build/) - Build governed agentic apps with an AI powered workflow builder.
 - [MeterCall](https://metercall.ai) - Universal API gateway over 10M+ APIs with AI router across 25+ models. Type a sentence in plain English, get a working app. 727+ ready-made modules to fork. Free tier, usage-based pricing.
 - [Taskade Genesis](https://docs.taskade.com/genesis-living-system-builder/genesis/) - AI-powered no-code app builder documentation. Build full-stack applications from natural language with integrated automation, AI agents, and workflow execution. Includes workspace DNA architecture and examples.
+- [VibeKit.bot](https://vibekit.bot) - Describe an app in chat and a persistent AI agent builds it, hosts it at its own domain, and keeps improving it with every message. Works from the iOS app or web; bring-your-own-key or free tier.
 - [Vibes DIY](https://vibes.diy/) - Open-source AI app builder: describe an app in plain English and get a live, shareable web app you can remix and collaborate on.
 
 ## AI-Assisted Development


### PR DESCRIPTION
Adds **[VibeKit.bot](https://vibekit.bot)** to the **Agentic Apps** section, in alphabetical order (between Taskade Genesis and Vibes DIY) per the contributing guidelines.

VibeKit.bot fits the section's pattern (Vibes DIY, Taskade Genesis, MeterCall): you describe an app in plain English and a persistent AI agent builds it, hosts it at its own live domain, and keeps iterating on it through chat — from the iOS app or the web. No code required; bring-your-own-key (Anthropic/OpenAI) or a free tier.

Note: named "VibeKit.bot" (with the domain) to avoid confusion with the unrelated `superagent-ai/vibekit` SDK.

Disclosure: I'm the maker.