### PR TITLE
Add Orion to Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 - [Rierino](https://rierino.com) - Developer-first low-code platform for building and orchestrating enterprise backend applications, microservices, and APIs with visual flow design and embedded AI. Free self-hosted Community Edition available.
 - [Nanonets Airtable Models](https://nanonets.com/airtable/) - Build a no-code AI image organizer with Airtable
 - [Oplim](https://oplim.com) - Custom Tasks on Your Website with Zero Code
+- [Orion](https://github.com/GoPlasmatic/Orion) - Self-hostable declarative services runtime with a no-code console; build and operate REST/Kafka services as JSON workflows on a single binary.
 - [Parabola](https://parabola.io) - Drag-and-drop to automate your repetitive tasks.
 - [Phantombuster](https://phantombuster.com) - A marketplace of simple to use no-code APIs
 - [pipedream](https://pipedream.com/) - The integration platform built for developers


### PR DESCRIPTION
Adds [Orion](https://github.com/GoPlasmatic/Orion) — a self-hostable declarative services runtime with a no-code console. REST/Kafka services are built and operated as JSON workflows on a single Rust binary, with built-in observability, rate limiting, and circuit breakers. Apache-2.0 licensed.

Per CONTRIBUTING: added to the Automation section in alphabetical order (after Oplim, before Parabola).