### PR TITLE
Add Hellomatik to Chatbots

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 - [Chatamo](https://chatamo.com) - Create intelligent voice and chat bots for marketing, sales and support in minutes.
 - [Chatfuel](https://chatfuel.com) - Create chatbots to engage with your audience on messengers
 - [Flow XO](https://flowxo.com) - Create a chatbot with zero coding skills required
+- [Hellomatik](https://hellomatik.com) - AI agents built from your company knowledge that answer, sell and book across WhatsApp, email and web.
 - [Instabot](https://instabot.io) - A Conversion Chatbot for Your Website
 - [Landbot](https://landbot.io) - Lead generation landing page as chatbot.
 - [Manychat](https://manychat.com) - Create a Messenger bot to engage your audience. No coding!


### PR DESCRIPTION
Adds **Hellomatik** to the Chatbots list (alphabetical order).

Hellomatik is a low-code AI agent platform: it turns a company's own knowledge into agents that answer, sell and book across WhatsApp, email and web. Single-line entry matched to the existing format. Thanks for the list!