### PR TITLE
Add InstaMaps to Web Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 - [Cloud Canal](https://www.cloudcanal.io) - Static Sites -> Web Apps
 - [Convertigo](https://www.convertigo.com/) - Create Web Applications with low code and no code
 - [Corvid](https://wix.com/corvid) - Build advanced web applications, hassle-free.
+- [InstaMaps](https://get-instamaps.com) - Turn a Google Sheet into a live map, store locator or delivery tracking app.
 - [MyVibe](https://myvibe.so/) - Instantly publish AI-generated web apps to permanent URLs in 60 seconds.
 - [OnOut](https://tools.onout.org/) - Build Blockchain DApps on your own domain in one-click.
 - [SpreadsheetWeb](https://www.spreadsheetweb.com) - A NoCode platform for Excel users


### PR DESCRIPTION
Adds [InstaMaps](https://get-instamaps.com) to Web Apps, placed alphabetically: turns a Google Sheet into a live map, store locator or delivery tracking app with no code — same spreadsheet-to-app category as SpreadsheetWeb, on the Google Sheets side. Free tier, no card. Happy to adjust placement or wording.