### PR TITLE
Add WeInc - AI website builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 - [Udesly](https://www.udesly.com) - Use Webflow to create WordPress and Shopify Themes
 - [Universe](https://onuniverse.com) - Make an awesome website from your phone.
 - [Versoly](https://versoly.com/) - The Easiest Way to Build Your SaaS Website
+- [WeInc](https://we.inc) - AI website builder that generates full React + Tailwind sites from a text prompt in under 60 seconds.
 - [Webflow](https://webflow.com/) - Break the code barrier, Build better business websites, faster. Without coding.
 - [Webstudio](https://webstudio.is/) - An Open Source alternative to Webflow. Much faster. No platform lock-in.
 - [Webstudio Managed by France Nuage](https://france-nuage.fr/) - Managed Webstudio hosting (open-source visual website builder, Webflow alternative) on sovereign French infrastructure.


### PR DESCRIPTION
Adding [WeInc](https://we.inc) to the Websites section.

WeInc is an AI website builder that generates full React + Tailwind sites from a text prompt in under 60 seconds. It uses WebContainers for in-browser development and supports custom domains, white-label reselling, and visual editing.

- Website: https://we.inc
- Pricing: Free tier + paid plans ($20-99/mo)
- Category: Website builder (AI-powered)