### PR TITLE
Add Autoposting to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 - [Ship](https://producthunt.com/ship) - A toolkit to ship awesome products, by Product Hunt ⛵️
 - [TinySnap](https://tinysnap.app) - A browser extension to capture screen and beautify screenshots
 - [TinyTools](https://tinytools-smoky.vercel.app/) - Free single-purpose marketing utilities (no signup, browser-based): OG image generator, SEO meta tag generator, AI robots.txt generator, AI content disclosure generator (EU AI Act compliant), favicon generator, color palette generator, and a domain name generator. Open source.
+- [Autoposting](https://autoposting.ai) - AI social media manager that writes, clips, and schedules posts to X, LinkedIn, Instagram, Threads and YouTube
 
 ## Mobile Apps
 


### PR DESCRIPTION
Adds [Autoposting](https://autoposting.ai) under Marketing.

No-code AI social media manager: writes posts in your own voice, clips long video into short-form, builds carousels, and schedules to X, LinkedIn, Instagram, Threads and YouTube. Free tier available.

One line added, entry style matches the surrounding list.