### PR TITLE
Add Ibis under Landing Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 ## Landing Pages
 
 - [EarlyBird](https://earlybird.im) - Create landing pages to validate early-stage business ideas.
+- [Ibis](https://cartonpliant.github.io/ibis/) - Compose a one-page commercial offer in the browser
 - [Instapage](https://instapage.com) - Landing pages, up to 6x more conversions.
 - [Launchaco](https://launchaco.com) - Simple landing pages for your startup
 - [Leadpages](https://leadpages.net) - Landing page builder & lead gen software.


### PR DESCRIPTION
Add Ibis to **Landing Pages** (alphabetical, after EarlyBird).

Ibis composes a one-page commercial offer in the browser. No account, no AI. Free with watermark, Pro 9€ (clean print + Markdown).

URL: https://cartonpliant.github.io/ibis/
Repo: https://github.com/CartonPliant/ibis

Not a quote or invoice tool.