### PR TITLE
Add Naratake to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 - [Jimdo](https://www.jimdo.com) - Your Website Builder‎
 - [Linkz.ai](https://linkz.ai) - Immersive hyperlink previews to keep visitors on your website
 - [Memberspace](https://www.memberspace.com) - Turn your audience into paying members.
+- [Naratake](https://naratake.com) - Website builder for local businesses — ordering, bookings and a back office on the published site, plus full source-code export.
 - [NoCodeVista](https://nocodevista.com) - Build and launch websites faster with a modern no-code builder focused on simplicity and speed
 - [Playcode](https://playcode.io/ai-website-builder) - AI website and app builder with hosting, visual editing, and custom domains.
 - [Sheet2Site](https://sheet2site.com) - Turn your 📗 Google Sheets into 🎨 professional websites


### PR DESCRIPTION
Disclosure up front: I build it.

Naratake is a no-code website builder for local businesses (restaurants, salons, trades). What makes it worth a slot in this section rather than one more generic builder: the industry starting points are working multi-page sites (a bakery opens with a priced case list and an enquiry form), online ordering and bookings run on the published site with its own back office, and the complete Next.js project can be exported — the same model as 8b's code export, but the export includes the database schema, REST API and admin panel when the site stores anything.

Entry is inserted alphabetically and follows the existing line format. Happy to adjust wording.