### PR TITLE
Add Busabase to Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 
 - [Airtable](https://airtable.com) - Database / Spreadsheet mashup
 - [Baserow](https://baserow.io/) - Open source no-code database and Airtable alternative
+- [Busabase](https://busabase.com) - Open source no-code database and Airtable alternative for AI agents; agents propose changes, humans approve them before they land
 - [NocoDB](https://github.com/nocodb/nocodb) - Free & Open Source Airtable Alternative - turns any SQL databases into smart spreadsheet.
 - [Forest Admin](https://www.forestadmin.com/) - The admin panel framework
 - [Go](https://www.123Go.io) - Low-Code for Enterprise Databases

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 
 - [Airtable](https://airtable.com) - Database / Spreadsheet mashup
 - [Baserow](https://baserow.io/) - Open source no-code database and Airtable alternative
-- [Busabase](https://busabase.com) - Open source no-code database and Airtable alternative for AI agents; agents propose changes, humans approve them before they land
+- [Busabase](https://busabase.com) - Open source AI-native workspace and database for AI agents; agents propose changes, humans review and approve them before they land
 - [NocoDB](https://github.com/nocodb/nocodb) - Free & Open Source Airtable Alternative - turns any SQL databases into smart spreadsheet.
 - [Forest Admin](https://www.forestadmin.com/) - The admin panel framework
 - [Go](https://www.123Go.io) - Low-Code for Enterprise Databases


### PR DESCRIPTION
Adds **Busabase** to `## Database`, in alphabetical order between Baserow and NocoDB.

```markdown
- [Busabase](https://busabase.com) - Open source self-hosted workspace and database for AI agents (Claude Code, Codex, or any MCP client): turns agent output into data, docs, skills and small apps you can reuse, with every change carrying its own diff, author and history
```

Busabase is an open-source (MIT), self-hostable workspace and database built for AI agents rather than adapted for them. Agents write records, docs, skills and small apps into it; each change carries its own message, diff, author and history, so the work accumulates instead of evaporating at the end of a session.

- Source: https://github.com/busabase/busabase (MIT)
- Live demo, no signup: https://demo.busabase.com
- Runs locally with `npx busabase server` or `docker run -p 15419:15419 busabase/busabase`

One housekeeping note: as a first-time contributor here my workflow run is sitting at "awaiting approval", so this PR shows no check results. Happy to rebase or reword if the entry needs adjusting.

Disclosure: I work on Busabase.
