### PR TITLE
Add APITable to Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ A curated list of delightful NoCode / LowCode applications and resources. For mo
 ## Database
 
 - [Airtable](https://airtable.com) - Database / Spreadsheet mashup
+- [APITable](https://github.com/apitable/apitable) - Open source API-oriented low-code database and Airtable alternative, self-hostable
 - [Baserow](https://baserow.io/) - Open source no-code database and Airtable alternative
 - [NocoDB](https://github.com/nocodb/nocodb) - Free & Open Source Airtable Alternative - turns any SQL databases into smart spreadsheet.
 - [Forest Admin](https://www.forestadmin.com/) - The admin panel framework


### PR DESCRIPTION
Adds **APITable** to `## Database`, in alphabetical order between Airtable and Baserow.

```markdown
- [APITable](https://github.com/apitable/apitable) - Open source API-oriented low-code database and Airtable alternative, self-hostable
```

APITable is an API-oriented low-code database and Airtable alternative — 15.6k stars, AGPL-3.0, self-hostable via Docker. It sits naturally alongside Baserow and NocoDB in this section; the distinguishing angle is that every table is exposed as a REST API by default, which makes it a building block for internal tools rather than only a spreadsheet.

- Source: https://github.com/apitable/apitable (AGPL-3.0)
- Hosted version: https://aitable.ai

One housekeeping note: as a first-time contributor here my workflow run is sitting at "awaiting approval", so this PR shows no check results.

Disclosure: I work on APITable.
